### PR TITLE
Update v1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Click on the rating button (the red square) to see information about enjoyment a
 ![Example (that'll show up once you download it)](resources/tier.png)
 
 If the rating doesn't load, <cb>refresh</c> the level page (It happens sometimes if you have the level saved already)
+The button can be moved to the level name (there's a setting for that)
 
 Adds a button on your profile that shows how many demons of each tier you've beaten
 
@@ -21,8 +22,8 @@ If you encounter any other issues, contact me on Discord (<cb>@b1rtek</c>) or on
 
 ## Special thanks
 
-<cb>*Code contributions:*</c> <cy>**[Diversion](https://github.com/B1rtek/Geode-GDDLIntegration/pull/3)**</c>
-<cg>*Feature suggestions:*</c> <cy>[MasterGamerY](https://github.com/B1rtek/Geode-GDDLIntegration/issues/1), [Weebifying](https://github.com/B1rtek/Geode-GDDLIntegration/pull/2), [averiee_](https://github.com/B1rtek/Geode-GDDLIntegration/milestone/4)</c>
-<cr>*Bug reporters:*</c> <cy>croozington, bllue, [Fleeym](https://github.com/geode-sdk/indexer/issues/557#issuecomment-1913780380), [matcool](https://github.com/geode-sdk/indexer/issues/557#issuecomment-1913780699)</c>
+<cb>*Code contributions:*</c> <cy>**[Diversion](https://github.com/B1rtek/Geode-GDDLIntegration/pull/3)**</c>  
+<cg>*Feature suggestions:*</c> <cy>[MasterGamerY](https://github.com/B1rtek/Geode-GDDLIntegration/issues/1), [Weebifying](https://github.com/B1rtek/Geode-GDDLIntegration/pull/2), [averiee_](https://github.com/B1rtek/Geode-GDDLIntegration/milestone/4), [thesuperjepphykiller](https://github.com/B1rtek/Geode-GDDLIntegration/issues/6)</c>
+<cr>*Bug reporters:*</c> <cy>croozington, bllue, [Fleeym](https://github.com/geode-sdk/indexer/issues/557#issuecomment-1913780380), [matcool](https://github.com/geode-sdk/indexer/issues/557#issuecomment-1913780699), [Lexicon](https://github.com/B1rtek/Geode-GDDLIntegration/issues/7)</c>
 
 

--- a/about.md
+++ b/about.md
@@ -5,7 +5,8 @@ Click on the rating button (the red square) to see information about enjoyment a
 
 ![Example (that'll show up once you download it)](b1rtek.gddlintegration/tier.png)
 
-If the rating doesn't load, <cb>refresh</c> the level page (It happens sometimes if you have the level saved already)
+If the rating doesn't load, <cb>refresh</c> the level page (It happens sometimes if you have the level saved already).  
+The button can be moved to the level name (there's a setting for that)
 
 Adds a button on your profile that shows how many demons of each tier you've beaten
 
@@ -22,7 +23,7 @@ If you encounter any other issues, contact me on Discord (<cb>@b1rtek</c>) or on
 ## Special thanks
 
 <cb>*Code contributions:*</c> <cy>**[Diversion](https://github.com/B1rtek/Geode-GDDLIntegration/pull/3)**</c>
-<cg>*Feature suggestions:*</c> <cy>[MasterGamerY](https://github.com/B1rtek/Geode-GDDLIntegration/issues/1), [Weebifying](https://github.com/B1rtek/Geode-GDDLIntegration/pull/2), [averiee_](https://github.com/B1rtek/Geode-GDDLIntegration/milestone/4)</c>
-<cr>*Bug reporters:*</c> <cy>croozington, bllue, [Fleeym](https://github.com/geode-sdk/indexer/issues/557#issuecomment-1913780380), [matcool](https://github.com/geode-sdk/indexer/issues/557#issuecomment-1913780699)</c>
+<cg>*Feature suggestions:*</c> <cy>[MasterGamerY](https://github.com/B1rtek/Geode-GDDLIntegration/issues/1), [Weebifying](https://github.com/B1rtek/Geode-GDDLIntegration/pull/2), [averiee_](https://github.com/B1rtek/Geode-GDDLIntegration/milestone/4), [thesuperjepphykiller](https://github.com/B1rtek/Geode-GDDLIntegration/issues/6)</c>
+<cr>*Bug reporters:*</c> <cy>croozington, bllue, [Fleeym](https://github.com/geode-sdk/indexer/issues/557#issuecomment-1913780380), [matcool](https://github.com/geode-sdk/indexer/issues/557#issuecomment-1913780699), [Lexicon](https://github.com/B1rtek/Geode-GDDLIntegration/issues/7)</c>
 
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+# v1.0.4
+- Added an option to move the tier rating button next to the level name (either on the right or the left side), the placement can be controlled with dedicated settings
+  - [feature suggestion by thesuperjepphykiller](https://github.com/B1rtek/Geode-GDDLIntegration/issues/6)
+- GDDL Demon Split info popup has more information now
+- Info showed after clicking the tier button on the level page has <cp>c</c><cr>o</c><co>l</c><cy>o</c><cg>r</c><cj>s</c> now
+- The game shouldn't crash anymore after opening the profile page now (added `geode.node-ids` as a dependency)
+  - [bug report from Lexicon](https://github.com/B1rtek/Geode-GDDLIntegration/issues/7)
+
 # v1.0.3
 Added the *GDDL Demon Split* screen, which shows how many demons of each tier you've beaten (according to a list that gets cached every 7 days)
 

--- a/mod.json
+++ b/mod.json
@@ -20,6 +20,17 @@
 			"description": "By default, the tier button is situated to the left of the demon face, if this is toggled on it'll be moved right to the level name",
 			"type": "bool",
 			"default": false
+		},
+		"pos-next-to-level-name": {
+			"name": "Position of the button next to the level name",
+			"description": "According to the slider position (on the left or the right side of the level name), works only if the setting above is ticked",
+			"type": "int",
+			"default": 1,
+			"min": -1,
+			"max": 1,
+			"control": {
+				"slider": true
+			}
 		}
 	}
 }

--- a/mod.json
+++ b/mod.json
@@ -13,5 +13,13 @@
 			"resources/split.png",
 			"resources/tiers/*.png"
 		]
+	},
+	"settings": {
+		"move-button-to-level-name": {
+			"name": "Move tier button to level name",
+			"description": "By default, the tier button is situated to the left of the demon face, if this is toggled on it'll be moved right to the level name",
+			"type": "bool",
+			"default": false
+		}
 	}
 }

--- a/mod.json
+++ b/mod.json
@@ -10,7 +10,7 @@
 	"dependencies": [
 		{
 			"id": "geode.node-ids",
-			"version": ">v1.1.4",
+			"version": ">=v1.1.4",
 			"importance": "required"
 		}
 	],

--- a/mod.json
+++ b/mod.json
@@ -7,6 +7,13 @@
 	"developer": "B1rtek",
 	"description": "Displays GDDL tiers of demons along with enjoyment ratings",
 	"repository": "https://github.com/B1rtek/Geode-GDDLIntegration",
+	"dependencies": [
+		{
+			"id": "geode.node-ids",
+			"version": ">v1.1.4",
+			"importance": "required"
+		}
+	],
 	"resources": {
 		"sprites": [
 			"resources/tier.png",
@@ -17,13 +24,13 @@
 	"settings": {
 		"move-button-to-level-name": {
 			"name": "Move tier button to level name",
-			"description": "By default, the tier button is situated to the left of the demon face, if this is toggled on it'll be moved right to the level name",
+			"description": "By default, the tier button is situated to the left of the demon face, if this is toggled on it'll be moved right to the level name.",
 			"type": "bool",
 			"default": false
 		},
 		"pos-next-to-level-name": {
 			"name": "Position of the button next to the level name",
-			"description": "According to the slider position (on the left or the right side of the level name), works only if the setting above is ticked",
+			"description": "According to the slider position (on the left or the right side of the level name), works only if the setting above is ticked.",
 			"type": "int",
 			"default": 1,
 			"min": -1,

--- a/src/GDDLDemonSplitLayer.cpp
+++ b/src/GDDLDemonSplitLayer.cpp
@@ -70,7 +70,14 @@ void GDDLDemonSplitLayer::onClose(cocos2d::CCObject *sender) {
 }
 
 void GDDLDemonSplitLayer::onInfo(cocos2d::CCObject *sender) {
-    FLAlertLayer::create("GDDL Demon Split", "Not accounting for <cb>official levels</c>, <co>gauntlet levels</c> and <cy>weekly demons</c>.", "OK")->show();
+    std::map<int, int> tierStats = RatingsManager::getTierStats();
+    int total = 0;
+    for (auto tierCountPair: tierStats) {
+        total += tierCountPair.second;
+    }
+    const int unrated = tierStats[-1];
+    const std::string message = "Not accounting for <cb>official levels</c>, <co>gauntlet levels</c> and <cy>weekly demons</c>.\n <cg>Total:</c> " + std::to_string(total) + ", of which with <cr>unknown</c> tier: " + std::to_string(unrated);
+    FLAlertLayer::create("GDDL Demon Split", message.c_str(), "OK")->show();
 }
 
 

--- a/src/LevelInfoLayer.cpp
+++ b/src/LevelInfoLayer.cpp
@@ -18,15 +18,20 @@ class $modify(GDDLInfoLayer, LevelInfoLayer) {
         if (starsLabel && isDemon) {
             m_fields->gddlTierUpdated = false;
             bool moveToLevelName = Mod::get()->getSettingValue<bool>("move-button-to-level-name");
+            int levelNamePos = Mod::get()->getSettingValue<int64_t>("pos-next-to-level-name");
 
             CCPoint menuPosition, buttonPosition;
             CCSize menuSize;
             float buttonScale = 1.0f;
-            if(moveToLevelName) {
+            if(moveToLevelName && levelNamePos != 0) {
                 const auto levelNameLabel = typeinfo_cast<CCLabelBMFont *>(getChildByID("title-label"));
                 const auto levelNamePosition = levelNameLabel->getPosition();
                 const auto levelNameSize = levelNameLabel->getContentSize();
-                menuPosition = CCPoint{levelNamePosition.x + levelNameSize.width/2.5f, levelNamePosition.y - levelNameSize.height/2.25f};
+                if (levelNamePos > 0) { // right
+                    menuPosition = CCPoint{levelNamePosition.x + levelNameSize.width/2.5f, levelNamePosition.y - levelNameSize.height/2.25f};
+                } else { // left
+                    menuPosition = CCPoint{levelNamePosition.x - levelNameSize.width/1.75f, levelNamePosition.y - levelNameSize.height/2.25f};
+                }
                 menuSize = CCSize{25, 25};
                 buttonPosition = CCPoint{12.5f, 12.5f};
                 buttonScale = 0.5f;

--- a/src/LevelInfoLayer.cpp
+++ b/src/LevelInfoLayer.cpp
@@ -30,7 +30,7 @@ class $modify(GDDLInfoLayer, LevelInfoLayer) {
                 if (levelNamePos > 0) { // right
                     menuPosition = CCPoint{levelNamePosition.x + levelNameSize.width/2.5f, levelNamePosition.y - levelNameSize.height/2.25f};
                 } else { // left
-                    menuPosition = CCPoint{levelNamePosition.x - levelNameSize.width/1.75f, levelNamePosition.y - levelNameSize.height/2.25f};
+                    menuPosition = CCPoint{levelNamePosition.x - levelNameSize.width/2.5f - 25.0f, levelNamePosition.y - levelNameSize.height/2.25f};
                 }
                 menuSize = CCSize{25, 25};
                 buttonPosition = CCPoint{12.5f, 12.5f};

--- a/src/LevelInfoLayer.cpp
+++ b/src/LevelInfoLayer.cpp
@@ -17,20 +17,25 @@ class $modify(GDDLInfoLayer, LevelInfoLayer) {
         bool isDemon = std::stoi(m_starsLabel->getString()) == 10;
         if (starsLabel && isDemon) {
             m_fields->gddlTierUpdated = false;
+            bool moveToLevelName = Mod::get()->getSettingValue<bool>("move-button-to-level-name");
 
-            auto diffPosition = m_difficultySprite->getPosition();
-            auto diffSize = m_difficultySprite->getContentSize();
-
-            auto menu = CCMenu::create();
-            menu->setPosition({diffPosition.x - 50 - diffSize.width/2, diffPosition.y - diffSize.height/3.2f});
-            menu->setContentSize({50, 50});
-            menu->setID("rating-menu"_spr);
-            addChild(menu);
-
-            auto button = CCMenuItemSpriteExtra::create(getDefaultSprite(), this, menu_selector(GDDLInfoLayer::onGDDLInfo));
-            button->setPosition({25, 25});
-            button->setID("rating"_spr);
-            menu->addChild(button);
+            CCPoint menuPosition, buttonPosition;
+            CCSize menuSize;
+            if(moveToLevelName) {
+                const auto levelNameLabel = typeinfo_cast<CCLabelBMFont *>(getChildByID("title-label"));
+                const auto levelNamePosition = levelNameLabel->getPosition();
+                const auto levelNameSize = levelNameLabel->getContentSize();
+                menuPosition = CCPoint{levelNamePosition.x + levelNameSize.width + 25.0f, levelNamePosition.y + levelNameSize.height/2};
+                menuSize = CCSize{50, 50};
+                buttonPosition = CCPoint{25, 25};
+            } else {
+                const auto diffPosition = m_difficultySprite->getPosition();
+                const auto diffSize = m_difficultySprite->getContentSize();
+                menuPosition = CCPoint{diffPosition.x - 50 - diffSize.width/2, diffPosition.y - diffSize.height/3.2f};
+                menuSize = CCSize{50, 50};
+                buttonPosition = CCPoint{25, 25};
+            }
+            placeGDDLButton(menuPosition, menuSize, buttonPosition);
 
             int levelID = m_level->m_levelID;
             int tier = RatingsManager::getDemonTier(levelID);
@@ -70,6 +75,19 @@ class $modify(GDDLInfoLayer, LevelInfoLayer) {
                 release();
             });
         }
+    }
+
+    void placeGDDLButton(const CCPoint& menuPosition, const CCSize& menuSize, const CCPoint& buttonPosition) {
+        auto menu = CCMenu::create();
+        menu->setPosition(menuPosition);
+        menu->setContentSize(menuSize);
+        menu->setID("rating-menu"_spr);
+        addChild(menu);
+
+        auto button = CCMenuItemSpriteExtra::create(getDefaultSprite(), this, menu_selector(GDDLInfoLayer::onGDDLInfo));
+        button->setPosition(buttonPosition);
+        button->setID("rating"_spr);
+        menu->addChild(button);
     }
 
     void updateButton(int tier) {

--- a/src/LevelInfoLayer.cpp
+++ b/src/LevelInfoLayer.cpp
@@ -21,13 +21,15 @@ class $modify(GDDLInfoLayer, LevelInfoLayer) {
 
             CCPoint menuPosition, buttonPosition;
             CCSize menuSize;
+            float buttonScale = 1.0f;
             if(moveToLevelName) {
                 const auto levelNameLabel = typeinfo_cast<CCLabelBMFont *>(getChildByID("title-label"));
                 const auto levelNamePosition = levelNameLabel->getPosition();
                 const auto levelNameSize = levelNameLabel->getContentSize();
-                menuPosition = CCPoint{levelNamePosition.x + levelNameSize.width + 25.0f, levelNamePosition.y + levelNameSize.height/2};
-                menuSize = CCSize{50, 50};
-                buttonPosition = CCPoint{25, 25};
+                menuPosition = CCPoint{levelNamePosition.x + levelNameSize.width/2.5f, levelNamePosition.y - levelNameSize.height/2.25f};
+                menuSize = CCSize{25, 25};
+                buttonPosition = CCPoint{12.5f, 12.5f};
+                buttonScale = 0.5f;
             } else {
                 const auto diffPosition = m_difficultySprite->getPosition();
                 const auto diffSize = m_difficultySprite->getContentSize();
@@ -35,7 +37,7 @@ class $modify(GDDLInfoLayer, LevelInfoLayer) {
                 menuSize = CCSize{50, 50};
                 buttonPosition = CCPoint{25, 25};
             }
-            placeGDDLButton(menuPosition, menuSize, buttonPosition);
+            placeGDDLButton(menuPosition, menuSize, buttonPosition, buttonScale);
 
             int levelID = m_level->m_levelID;
             int tier = RatingsManager::getDemonTier(levelID);
@@ -77,10 +79,11 @@ class $modify(GDDLInfoLayer, LevelInfoLayer) {
         }
     }
 
-    void placeGDDLButton(const CCPoint& menuPosition, const CCSize& menuSize, const CCPoint& buttonPosition) {
+    void placeGDDLButton(const CCPoint& menuPosition, const CCSize& menuSize, const CCPoint& buttonPosition, float buttonScale = 1.0f) {
         auto menu = CCMenu::create();
         menu->setPosition(menuPosition);
         menu->setContentSize(menuSize);
+        menu->setScale(buttonScale);
         menu->setID("rating-menu"_spr);
         addChild(menu);
 

--- a/src/LevelInfoLayer.cpp
+++ b/src/LevelInfoLayer.cpp
@@ -142,7 +142,7 @@ class $modify(GDDLInfoLayer, LevelInfoLayer) {
         std::string enjoyment = info.enjoyment == -1 ? "N/A" : Utils::floatToString(info.enjoyment, 2);
         std::string submissionCount = info.submissionCount == -1 ? "N/A" : std::to_string(info.submissionCount);
 
-        auto layer = FLAlertLayer::create("GDDL Information", "Tier: " + tier + "\nEnjoyment: " + enjoyment + "\nTotal submissions: " + submissionCount, "Close");
+        auto layer = FLAlertLayer::create("GDDL Information", "<cr>Tier:</c> " + tier + "\n<cg>Enjoyment:</c> " + enjoyment + "\n<cy>Total submissions:</c> " + submissionCount, "Close");
         layer->show();
     }
 };


### PR DESCRIPTION
- Added an option to move the tier rating button next to the level name (either on the right or the left side), the placement can be controlled with dedicated settings
  - [feature suggestion by thesuperjepphykiller](https://github.com/B1rtek/Geode-GDDLIntegration/issues/6)
- GDDL Demon Split info popup has more information now
- Info showed after clicking the tier button on the level page has <cp>c</c><cr>o</c><co>l</c><cy>o</c><cg>r</c><cj>s</c> now
- The game shouldn't crash anymore after opening the profile page now (added `geode.node-ids` as a dependency)
  - [bug report from Lexicon](https://github.com/B1rtek/Geode-GDDLIntegration/issues/7)
