### PR TITLE
v1.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,24 @@
 # <cr> GDDL Integration </c>
 
-Displays <cr>**GDDL tiers**</c> next to demon ratings as well as the reported <cb>enjoyment</c> ratings.  
-Click on the rating button (the red square) to see information about enjoyment and the amount of ratings.
+## Features
+- Displays <cr>GDDL ratings</c> of demon levels, click on the <cb>button</c> to see more info about the level
+- Includes a <cy>superior to Rob's</c> demon searching UI - allowing to search by a part of the level name, GDDL tiers <co>and more!</c>
+- If you want to just search for levels from a tier, there's a <cp>simpler UI</c> hidden behind an <cg>arrow button</c> in the bottom right corner
+- Adds a <cr>GDDL Tier Split</c> page showing how many levels of which tier you've completed, click on the tier labels to see the completed levels
 
-![Example (that'll show up once you download it)](resources/tier.png)
+**<cy>Positions of UI elements can be adjusted in the settings, be sure to visit them if one of your other mods overlaps UI elements with this one</c>**
 
-If the rating doesn't load, <cb>refresh</c> the level page (It happens sometimes if you have the level saved already)
-The button can be moved to the level name (there's a setting for that)
-
-You can search for levels based on their tier or enjoyment rating, completion status etc. in the new GDDL Search menu
-
-![Example of the new search menu](resources/search.png)
-
-If you prefer, you can switch to a simpler search menu using the green arrow button in the bottom right corner
-
-![Example of the old search menu](resources/old_search.png)
-
-Adds a button on your profile that shows how many demons of each tier you've beaten
-
-![Another example visible only to those who downloaded this mod](resources/split.png)
+## Gallery
+![Example of a tier rating displaying on the level page](resources/tier.png)
+![Example of the full search menu](resources/search.png)
+![Example of the simple search menu](resources/old_search.png)
+![GDDL Tier Split menu](resources/split.png)
 
 ## Known issues
-
-- <cy>Usernames</c> sometimes turn into <cy>`-`</c> after a <cr>failed</c> request, this is just cosmetic though (
-  [apparently Rob's fault](https://github.com/geode-sdk/indexer/issues/557#issuecomment-1913375319))
+If you encounter an <cy>issue</c> with the mod, [open an issue in the mod's GitHub repo](https://github.com/B1rtek/Geode-GDDLIntegration/issues/new/choose) or contact me on Discord (<cb>@b1rtek</c>)
+- <cy>Usernames</c> sometimes turn into <cy>`-`</c> after a <cr>failed</c> request, this is just cosmetic though ([apparently Rob's fault](https://github.com/geode-sdk/indexer/issues/557#issuecomment-1913375319))
 - Opening the *GDDL Demon Split* popup <co>might</c> cause a lag, don't worry about that :)
-- Going back from the *GDDL Search* popup goes back to the creator layer instead of the search layer
-- The level browser might display a button which should allow you to go to the next page of results even though there might be no more pages
-
-If you encounter any other issues, contact me on Discord (<cb>@b1rtek</c>) or on Github
+- The level browser <co>might</c> display a button which should allow you to go to the next page of results even though there might be no more pages
 
 ## Special thanks
 

--- a/about.md
+++ b/about.md
@@ -1,34 +1,24 @@
 # <cr> GDDL Integration </c>
 
-Displays <cr>**GDDL tiers**</c> next to demon ratings as well as the reported <cb>enjoyment</c> ratings.  
-Click on the rating button (the red square) to see information about enjoyment and the amount of ratings.
+## Features
+- Displays <cr>GDDL ratings</c> of demon levels, click on the <cb>button</c> to see more info about the level
+- Includes a <cy>superior to Rob's</c> demon searching UI - allowing to search by a part of the level name, GDDL tiers <co>and more!</c>
+- If you want to just search for levels from a tier, there's a <cp>simpler UI</c> hidden behind an <cg>arrow button</c> in the bottom right corner
+- Adds a <cr>GDDL Tier Split</c> page showing how many levels of which tier you've completed, click on the tier labels to see the completed levels
 
-![Example (that'll show up once you download it)](b1rtek.gddlintegration/tier.png)
+**<cy>Positions of UI elements can be adjusted in the settings, be sure to visit them if one of your other mods overlaps UI elements with this one</c>**
 
-If the rating doesn't load, <cb>refresh</c> the level page (It happens sometimes if you have the level saved already).  
-The button can be moved to the level name (there's a setting for that)
-
-You can search for levels based on their tier or enjoyment rating, completion status etc. in the new GDDL Search menu
-
-![Example of the new search menu](b1rtek.gddlintegration/search.png)
-
-If you prefer, you can switch to a simpler search menu using the green arrow button in the bottom right corner
-
-![Example of the old search menu](b1rtek.gddlintegration/old_search.png)
-
-Adds a button on your profile that shows how many demons of each tier you've beaten
-
-![Another example visible only to those who downloaded this mod](b1rtek.gddlintegration/split.png)
+## Gallery
+![Example of a tier rating displaying on the level page](b1rtek.gddlintegration/tier.png)
+![Example of the full search menu](b1rtek.gddlintegration/search.png)
+![Example of the simple search menu](b1rtek.gddlintegration/old_search.png)
+![GDDL Tier Split menu](b1rtek.gddlintegration/split.png)
 
 ## Known issues
-
-- <cy>Usernames</c> sometimes turn into <cy>`-`</c> after a <cr>failed</c> request, this is just cosmetic though (
-  [apparently Rob's fault](https://github.com/geode-sdk/indexer/issues/557#issuecomment-1913375319))
+If you encounter an <cy>issue</c> with the mod, [open an issue in the mod's GitHub repo](https://github.com/B1rtek/Geode-GDDLIntegration/issues/new/choose) or contact me on Discord (<cb>@b1rtek</c>)
+- <cy>Usernames</c> sometimes turn into <cy>`-`</c> after a <cr>failed</c> request, this is just cosmetic though ([apparently Rob's fault](https://github.com/geode-sdk/indexer/issues/557#issuecomment-1913375319))
 - Opening the *GDDL Demon Split* popup <co>might</c> cause a lag, don't worry about that :)
-- Going back from the *GDDL Search* popup goes back to the creator layer instead of the search layer
-- The level browser might display a button which should allow you to go to the next page of results even though there might be no more pages
-
-If you encounter any other issues, contact me on Discord (<cb>@b1rtek</c>) or on Github
+- The level browser <co>might</c> display a button which should allow you to go to the next page of results even though there might be no more pages
 
 ## Special thanks
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# v1.1.2
+- Going back from search results goes back to the right place (finally!)
+- Added a missing alert saying that the rating is still loading (while it's actually loading)
+- Updated the search menu to be compatible with the new GDDL API version
+
 # v1.1.1
 - The old search menu can be opened with a click on a green arrow on the bottom right of the search popup
 - Android users can finally input the correct amount of characters into text fields

--- a/mod.json
+++ b/mod.json
@@ -1,6 +1,6 @@
 {
 	"geode": "2.0.0",
-	"version": "v1.1.1",
+	"version": "v1.1.2",
 	"gd": {
 		"android": "2.205",
 		"win": "2.204"
@@ -8,7 +8,7 @@
 	"id": "b1rtek.gddlintegration",
 	"name": "GDDL Integration",
 	"developer": "B1rtek",
-	"description": "Displays GDDL tiers of demons along with enjoyment ratings",
+	"description": "Integration with Geometry Dash Demon Ladder - level tiers, search and more",
 	"repository": "https://github.com/B1rtek/Geode-GDDLIntegration",
 	"dependencies": [
 		{

--- a/src/GDDLDemonSplitLayer.cpp
+++ b/src/GDDLDemonSplitLayer.cpp
@@ -96,6 +96,11 @@ void GDDLDemonSplitLayer::onTierSearch(cocos2d::CCObject *sender) { // NOLINT(*-
     // the list should display itself hopefully
 }
 
+void GDDLDemonSplitLayer::onEnter() {
+    FLAlertLayer::onEnter();
+    cocos::handleTouchPriority(this);
+}
+
 CCNode *GDDLDemonSplitLayer::createTierNode(const int tier) {
     const auto tierNode = CCMenu::create();
     tierNode->setLayout(RowLayout::create()->setGap(3.0f)->setAutoScale(true));

--- a/src/GDDLDemonSplitLayer.h
+++ b/src/GDDLDemonSplitLayer.h
@@ -12,6 +12,7 @@ class GDDLDemonSplitLayer final : public FLAlertLayer {
     void onClose(cocos2d::CCObject* sender);
     void onInfo(cocos2d::CCObject *sender);
     void onTierSearch(cocos2d::CCObject* sender);
+    void onEnter() override;
 
     CCNode* createTierNode(int tier);
 public:

--- a/src/GDDLSearchLayer.cpp
+++ b/src/GDDLSearchLayer.cpp
@@ -516,6 +516,8 @@ std::vector<int> GDDLSearchLayer::parseResponse(const std::string& response) {
         const int levelID = element["LevelID"];
         if (levelID > 3) { // to avoid official demons
             results.push_back(element["LevelID"]);
+            const float rating = element["Rating"];
+            RatingsManager::updateCacheFromSearch(levelID, rating);
         }
     }
     return results;

--- a/src/GDDLSearchLayer.cpp
+++ b/src/GDDLSearchLayer.cpp
@@ -465,7 +465,7 @@ std::string GDDLSearchLayer::formSearchRequest() {
     request += addStringToRequest("name", name);
     request += addValueToRequest("lowTier", lowTier, 0);
     request += addValueToRequest("highTier", highTier, 0);
-    request += addValueToRequest("difficulty", difficulty+1, 7); // API 1.9.0 - diffs 1-5
+    request += addValueToRequest("difficulty", difficulty+1, 6); // API 1.9.0 - diffs 1-5
     request += addStringToRequest("creator", creator);
     request += addStringToRequest("song", song);
     request += addBoolToRequest("exactName", exactName);
@@ -603,7 +603,10 @@ void GDDLSearchLayer::handleSearchObject(GJSearchObject *searchObject, GDDLBrows
         callbackObject->handleSearchObject(searchObject, resultsCount);
     } else { // new search
         const auto listLayer = LevelBrowserLayer::create(searchObject);
-        cocos::switchToScene(listLayer);
+        const auto listLayerScene = CCScene::create();
+        listLayerScene->addChild(listLayer);
+        auto transition = CCTransitionFade::create(0.5, listLayerScene);
+        CCDirector::sharedDirector()->pushScene(transition);
     }
 }
 

--- a/src/GDDLSearchLayer.cpp
+++ b/src/GDDLSearchLayer.cpp
@@ -465,7 +465,7 @@ std::string GDDLSearchLayer::formSearchRequest() {
     request += addStringToRequest("name", name);
     request += addValueToRequest("lowTier", lowTier, 0);
     request += addValueToRequest("highTier", highTier, 0);
-    request += addValueToRequest("difficulty", difficulty+2, 7);
+    request += addValueToRequest("difficulty", difficulty+1, 7); // API 1.9.0 - diffs 1-5
     request += addStringToRequest("creator", creator);
     request += addStringToRequest("song", song);
     request += addBoolToRequest("exactName", exactName);

--- a/src/GDDLSearchLayer.cpp
+++ b/src/GDDLSearchLayer.cpp
@@ -410,9 +410,10 @@ void GDDLSearchLayer::onClose(CCObject *sender) {
     setKeypadEnabled(false);
     removeFromParentAndCleanup(true);
 }
+
 TodoReturn GDDLSearchLayer::keyBackClicked() {
     saveValues();
-    FLAlertLayer::keyBackClicked();
+    FLAlertLayer::keyBackClicked(); // calls onClose I think
 }
 
 // ReSharper disable once CppMemberFunctionMayBeStatic
@@ -1026,6 +1027,12 @@ float GDDLSearchLayer::getFloatTextfieldValue(CCTextInputNode *&textfield) {
     if (textfield->getString().empty())
         return 0;
     return std::stof(textfield->getString());
+}
+
+void GDDLSearchLayer::onEnter()
+{
+    FLAlertLayer::onEnter();
+    cocos::handleTouchPriority(this);
 }
 
 GDDLSearchLayer *GDDLSearchLayer::create() {

--- a/src/GDDLSearchLayer.cpp
+++ b/src/GDDLSearchLayer.cpp
@@ -516,8 +516,10 @@ std::vector<int> GDDLSearchLayer::parseResponse(const std::string& response) {
         const int levelID = element["LevelID"];
         if (levelID > 3) { // to avoid official demons
             results.push_back(element["LevelID"]);
-            const float rating = element["Rating"];
-            RatingsManager::updateCacheFromSearch(levelID, rating);
+            if(!element["Rating"].is_null()) {
+                const float rating = element["Rating"];
+                RatingsManager::updateCacheFromSearch(levelID, rating);
+            }
         }
     }
     return results;

--- a/src/GDDLSearchLayer.h
+++ b/src/GDDLSearchLayer.h
@@ -23,7 +23,7 @@ class GDDLSearchLayer final : public FLAlertLayer {
     inline static int lowTier = 0, highTier = 0;
     // difficulty - passed as a number from 2 to 6, shown as strings from the vector below, 5 = any
     // 1 is actually reserved for "Official" demons, but since they can't be displayed in a level browser, we can use it
-    // 0 is for nothing - just add 2 to the index and we're good
+    // 0 is for nothing - just add 1 (API 1.9.0 change) to the index and we're good
     inline static int difficulty = 5;
     const inline static std::vector<std::string> demonDifficulties = {
             "Easy", "Medium", "Hard", "Insane", "Extreme", "Any"

--- a/src/GDDLSearchLayer.h
+++ b/src/GDDLSearchLayer.h
@@ -195,6 +195,7 @@ class GDDLSearchLayer final : public FLAlertLayer {
     // getters for the same thing
     static int getNumberTextfieldValue(CCTextInputNode *&textfield);
     static float getFloatTextfieldValue(CCTextInputNode *&textfield);
+    void onEnter() override;
 
 public:
     static GDDLSearchLayer *create();

--- a/src/LevelInfoLayer.cpp
+++ b/src/LevelInfoLayer.cpp
@@ -181,8 +181,10 @@ class $modify(GDDLInfoLayer, LevelInfoLayer) {
     // ReSharper disable once CppMemberFunctionMayBeConst
     void onGDDLInfo(CCObject *sender) {
         const auto rating = RatingsManager::getRating(m_level->m_levelID);
-        if (!rating)
+        if (!rating) {
+            FLAlertLayer::create("GDDL Information", "Still loading...", "OK")->show();
             return;
+        }
         const auto info = rating.value();
 
         const std::string tier = info.rating == -1 ? "N/A" : Utils::floatToString(info.rating, 2);

--- a/src/RatingsManager.cpp
+++ b/src/RatingsManager.cpp
@@ -170,7 +170,10 @@ bool RatingsManager::alreadyCached() {
     return !ratingsCache.empty();
 }
 
-void RatingsManager::updateCacheFromSearch(const int levelID, const int tier) { ratingsCache[levelID] = tier; }
+void RatingsManager::updateCacheFromSearch(const int levelID, const float rating) {
+    const int tier = static_cast<int>(std::round(rating));
+    ratingsCache[levelID] = tier;
+}
 
 int RatingsManager::getCachedTier(const int levelID) {
     return !ratingsCache.contains(levelID) ? -1 : ratingsCache[levelID];

--- a/src/RatingsManager.h
+++ b/src/RatingsManager.h
@@ -40,7 +40,7 @@ public:
 
     static bool alreadyCached();
 
-    static void updateCacheFromSearch(int levelID, int tier);
+    static void updateCacheFromSearch(int levelID, const float rating);
 
     static int getCachedTier(int levelID);
 };


### PR DESCRIPTION
# v1.1.2
- Going back from search results goes back to the right place (finally!)
- Added a missing alert saying that the rating is still loading (while it's actually loading)
- Updated the search menu to be compatible with the new GDDL API version