### PR TITLE
Fix LevelSelectLayer tower exit crash

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,10 +50,6 @@ class $modify(MenuLayer) {
         GDDLSearchLayer::stopSearch();
         GDDLSearchLayer::restoreValuesAfterSplit();
         GDDLSearchLayer::saveSettings();
-        // keyBackClicked() being broken on android workaround
-#ifdef GEODE_IS_ANDROID
-        GDDLRobtopLevelsLayer::backActions();
-#endif
         if (!RatingsManager::alreadyCached() && !RatingsManager::triedToCache) { // TODO triedToCache is never written to
             RatingsManager::triedToCache = true;
             Utils::bindCacheDownloadCallback(m_fields->cacheEventListener);

--- a/src/modified/GDDLRobtopLevelsLayer.cpp
+++ b/src/modified/GDDLRobtopLevelsLayer.cpp
@@ -6,7 +6,7 @@ bool GDDLRobtopLevelsLayer::init(int page) {
     if (!LevelSelectLayer::init(page)) {
         return false;
     }
-    m_fields->beingBrowsed = true;
+    Fields::beingBrowsed = true;
     GDDLBoomScrollLayer::Fields::robtopLevelsLayer = this;
     // setup potential web req
     m_fields->robtopLevelsLayerGetRatingListener.bind([this](web::WebTask::Event* e) {
@@ -63,20 +63,7 @@ void GDDLRobtopLevelsLayer::swiped(const int newPage) {
     pageChanged(previousPage);
 }
 
-void GDDLRobtopLevelsLayer::onBack(CCObject* sender) {
-    LevelSelectLayer::onBack(sender);
-    backActions();
-}
-
-// keyBackClicked() being broken on android workaround
-#ifndef GEODE_IS_ANDROID
-void GDDLRobtopLevelsLayer::keyBackClicked() {
-    LevelSelectLayer::keyBackClicked();
-    backActions();
-}
-#endif
-
-void GDDLRobtopLevelsLayer::backActions() {
+GDDLRobtopLevelsLayer::Fields::~Fields() {
     Fields::beingBrowsed = false;
     GDDLBoomScrollLayer::Fields::robtopLevelsLayer = nullptr;
 }

--- a/src/modified/GDDLRobtopLevelsLayer.h
+++ b/src/modified/GDDLRobtopLevelsLayer.h
@@ -30,6 +30,7 @@ struct GDDLRobtopLevelsLayer : public geode::Modify<GDDLRobtopLevelsLayer, Level
         bool changedBySwiping = false;
         EventListener<web::WebTask> robtopLevelsLayerGetRatingListener;
         GDDLAdvancedLevelInfoPopup* advancedLevelInfoPopup = nullptr;
+        ~Fields();
     };
 
     bool init(int page);
@@ -39,13 +40,6 @@ struct GDDLRobtopLevelsLayer : public geode::Modify<GDDLRobtopLevelsLayer, Level
     void onPrev(CCObject *sender);
 
     void swiped(const int newPage);
-
-    void onBack(CCObject *sender);
-
-    // keyBackClicked() being broken on android workaround
-#ifndef GEODE_IS_ANDROID
-    virtual void keyBackClicked();
-#endif
 
     void pageChanged(int previousPage);
 
@@ -60,9 +54,6 @@ struct GDDLRobtopLevelsLayer : public geode::Modify<GDDLRobtopLevelsLayer, Level
     void onGDDLInfo(CCObject *sender);
 
     void updateButton(const int tier);
-
-public:
-    static void backActions();
 };
 
 #endif //GDDLROBTOPLEVELSLAYER_H


### PR DESCRIPTION
Utilizes Fields destructor instead of back button hooks